### PR TITLE
Switch to using reverse domain mod IDs to align with client mods

### DIFF
--- a/10CustomRoute/CustomStaticRouter.cs
+++ b/10CustomRoute/CustomStaticRouter.cs
@@ -17,7 +17,7 @@ namespace _10CustomRoute;
 /// </summary>
 public record ModMetadata : AbstractModMetadata
 {
-    public override string ModId { get; set; } = "customroute.6870ceefe659e12494df79f4";
+    public override string ModId { get; set; } = "com.sp-tarkov.examples.customroute";
     public override string Name { get; set; } = "CustomStaticRouterExample";
     public override string Author { get; set; } = "SPTarkov";
     public override List<string>? Contributors { get; set; }

--- a/11RegisterClassesInDI/RegisterClassesInDI.cs
+++ b/11RegisterClassesInDI/RegisterClassesInDI.cs
@@ -15,7 +15,7 @@ namespace _11RegisterClassesInDI;
 /// </summary>
 public record ModMetadata : AbstractModMetadata
 {
-    public override string ModId { get; set; } = "registerclassesindi.6870d0fb01cf7d4ed6344b3d";
+    public override string ModId { get; set; } = "com.sp-tarkov.examples.registerclassesindi";
     public override string Name { get; set; } = "RegisterClassesInDIExample";
     public override string Author { get; set; } = "SPTarkov";
     public override List<string>? Contributors { get; set; }

--- a/13.1AddTraderWithDynamicAssorts/AddTraderWithDynamicAssorts.cs
+++ b/13.1AddTraderWithDynamicAssorts/AddTraderWithDynamicAssorts.cs
@@ -17,7 +17,7 @@ namespace _13._1AddTraderWithDynamicAssorts;
 
 public record ModMetadata : AbstractModMetadata
 {
-    public override string ModId { get; set; } = "addtraderdynamicassorts.6870d11fd2b2a0557900a53c";
+    public override string ModId { get; set; } = "com.sp-tarkov.examples.addtraderdynamicassorts";
     public override string Name { get; set; } = "AddTraderWithDynamicAssortsExample";
     public override string Author { get; set; } = "SPTarkov";
     public override List<string>? Contributors { get; set; } = ["Clodan", "CWX"];

--- a/13AddTraderWithAssortJson/AddTraderWithAssortJson.cs
+++ b/13AddTraderWithAssortJson/AddTraderWithAssortJson.cs
@@ -15,7 +15,7 @@ namespace _13AddTraderWithAssortJson;
 // This record holds the various properties for your mod
 public record ModMetadata : AbstractModMetadata
 {
-    public override string ModId { get; set; } = "addtraderjsonassorts.6870d1d3f83f3ea3b4192b56";
+    public override string ModId { get; set; } = "com.sp-tarkov.examples.addtraderjsonassorts";
     public override string Name { get; set; } = "AddTraderWithAssortJsonExample";
     public override string Author { get; set; } = "SPTarkov";
     public override List<string>? Contributors { get; set; } = ["Clodan", "CWX"];

--- a/14AfterDBLoadHook/AfterDBLoadHook.cs
+++ b/14AfterDBLoadHook/AfterDBLoadHook.cs
@@ -11,7 +11,7 @@ namespace _14AfterDBLoadHook;
 
 public record ModMetadata : AbstractModMetadata
 {
-    public override string ModId { get; set; } = "afterdbhook.6870d1f820c19a8dcd60e2af";
+    public override string ModId { get; set; } = "com.sp-tarkov.examples.afterdbhook";
     public override string Name { get; set; } = "AfterDBLoadHookExample";
     public override string Author { get; set; } = "SPTarkov";
     public override List<string>? Contributors { get; set; }

--- a/15HttpListenerExample/HttpListenerExample.cs
+++ b/15HttpListenerExample/HttpListenerExample.cs
@@ -6,7 +6,7 @@ namespace _15HttpListenerExample;
 
 public record ModMetadata : AbstractModMetadata
 {
-    public override string ModId { get; set; } = "httplistener.6870d292a830085ca7d86c54";
+    public override string ModId { get; set; } = "com.sp-tarkov.examples.httplistener";
     public override string Name { get; set; } = "HttpListenerExample";
     public override string Author { get; set; } = "SPTarkov";
     public override List<string>? Contributors { get; set; }

--- a/18.1CustomItemServiceLootBox/CustomItemServiceLootBox.cs
+++ b/18.1CustomItemServiceLootBox/CustomItemServiceLootBox.cs
@@ -12,7 +12,7 @@ namespace _18._1CustomItemServiceLootBox;
 
 public record ModMetadata : AbstractModMetadata
 {
-    public override string ModId { get; set; } = "customitemlootbox.6870d2b5b8301c91ede957c4";
+    public override string ModId { get; set; } = "com.sp-tarkov.examples.customitemlootbox";
     public override string Name { get; set; } = "CustomItemServiceLootBoxExample";
     public override string Author { get; set; } = "SPTarkov";
     public override List<string>? Contributors { get; set; }

--- a/18CustomItemService/CustomItemServiceExample.cs
+++ b/18CustomItemService/CustomItemServiceExample.cs
@@ -9,7 +9,7 @@ namespace _18CustomItemService;
 
 public record ModMetadata : AbstractModMetadata
 {
-    public override string ModId { get; set; } = "customitem.6870d2d3ca588a42ea0f93c7";
+    public override string ModId { get; set; } = "com.sp-tarkov.examples.customitem";
     public override string Name { get; set; } = "CustomItemServiceExample";
     public override string Author { get; set; } = "SPTarkov";
     public override List<string>? Contributors { get; set; }

--- a/1Logging/Logging.cs
+++ b/1Logging/Logging.cs
@@ -19,11 +19,10 @@ public record ModMetadata : AbstractModMetadata
     /// <summary>
     /// Any string can be used for a modId, but it should ideally be unique and not easily duplicated
     /// a 'bad' ID would be: "mymod", "mod1", "questmod"
-    /// Optionality, you can add a mongoId to the end of the id to make it extra unique
-    /// use : https://observablehq.com/@hugodf/mongodb-objectid-generator
-    /// or: https://nddapp.com/object-id-generator.html
+    /// It is recommended (but not mandatory) to use the reverse domain name notation,
+    /// see: https://docs.oracle.com/javase/tutorial/java/package/namingpkgs.html
     /// </summary>
-    public override string ModId { get; set; } = "logging.687011b72fdaac3ca10224de";
+    public override string ModId { get; set; } = "com.sp-tarkov.examples.logging";
 
     /// <summary>
     /// The name of your mod

--- a/20CustomChatBot/CustomChatBot.cs
+++ b/20CustomChatBot/CustomChatBot.cs
@@ -11,7 +11,7 @@ namespace _20CustomChatBot;
 
 public record ModMetadata : AbstractModMetadata
 {
-    public override string ModId { get; set; } = "customchatbot.6870fc5c0680d79924b8ec0c";
+    public override string ModId { get; set; } = "com.sp-tarkov.examples.customchatbot";
     public override string Name { get; set; } = "CustomChatBotExample";
     public override string Author { get; set; } = "SPTarkov";
     public override List<string>? Contributors { get; set; }

--- a/21CustomCommandoCommand/CustomCommandoCommand.cs
+++ b/21CustomCommandoCommand/CustomCommandoCommand.cs
@@ -11,7 +11,7 @@ namespace _21CustomCommandoCommand;
 
 public record ModMetadata : AbstractModMetadata
 {
-    public override string ModId { get; set; } = "customcommandocommand.6870fc7bf59ddcc1469cceda";
+    public override string ModId { get; set; } = "com.sp-tarkov.examples.customcommandocommand";
     public override string Name { get; set; } = "CustomCommandoCommandExample";
     public override string Author { get; set; } = "SPTarkov";
     public override List<string>? Contributors { get; set; }

--- a/22CustomSptCommand/CustomSptCommand.cs
+++ b/22CustomSptCommand/CustomSptCommand.cs
@@ -11,7 +11,7 @@ namespace _22CustomSptCommand;
 
 public record ModMetadata : AbstractModMetadata
 {
-    public override string ModId { get; set; } = "customsptcommand.6870fc98292f7983f5f791cb";
+    public override string ModId { get; set; } = "com.sp-tarkov.examples.customsptcommand";
     public override string Name { get; set; } = "CustomCommandoCommandExample";
     public override string Author { get; set; } = "SPTarkov";
     public override List<string>? Contributors { get; set; }

--- a/23CustomAbstractChatBot/CustomAbstractChatBot.cs
+++ b/23CustomAbstractChatBot/CustomAbstractChatBot.cs
@@ -11,7 +11,7 @@ namespace _23CustomAbstractChatBot;
 
 public record ModMetadata : AbstractModMetadata
 {
-    public override string ModId { get; set; } = "customabstractchatbot.6870fcb0e8853ff88b060e34";
+    public override string ModId { get; set; } = "com.sp-tarkov.examples.customabstractchatbot";
     public override string Name { get; set; } = "CustomAbstractChatBotExample";
     public override string Author { get; set; } = "SPTarkov";
     public override List<string>? Contributors { get; set; }

--- a/24Websocket/WebsocketConnectionHandler.cs
+++ b/24Websocket/WebsocketConnectionHandler.cs
@@ -9,7 +9,7 @@ namespace _24Websocket;
 
 public record ModMetadata : AbstractModMetadata
 {
-    public override string ModId { get; set; } = "websocket.6870fccfb9b3615d166ebbb8";
+    public override string ModId { get; set; } = "com.sp-tarkov.examples.websocket";
     public override string Name { get; set; } = "CustomWebSocketConnectionHandlerExample";
     public override string Author { get; set; } = "SPTarkov";
     public override List<string>? Contributors { get; set; }

--- a/25AddCustomLocales/AddCustomLocales.cs
+++ b/25AddCustomLocales/AddCustomLocales.cs
@@ -8,7 +8,7 @@ namespace _25AddCustomLocales;
 
 public record ModMetadata : AbstractModMetadata
 {
-    public override string ModId { get; set; } = "customlocales.6870fce2fec56cded28420d2";
+    public override string ModId { get; set; } = "com.sp-tarkov.examples.customlocales";
     public override string Name { get; set; } = "AddCustomLocalesExample";
     public override string Author { get; set; } = "SPTarkov";
     public override List<string>? Contributors { get; set; }

--- a/2EditDatabase/EditDatabaseValues.cs
+++ b/2EditDatabase/EditDatabaseValues.cs
@@ -20,11 +20,10 @@ public record ModMetadata : AbstractModMetadata
     /// <summary>
     /// Any string can be used for a modId, but it should ideally be unique and not easily duplicated
     /// a 'bad' ID would be: "mymod", "mod1", "questmod"
-    /// Optionality, you can add a mongoId to the end of the id to make it extra unique
-    /// use : https://observablehq.com/@hugodf/mongodb-objectid-generator
-    /// or: https://nddapp.com/object-id-generator.html
+    /// It is recommended (but not mandatory) to use the reverse domain name notation,
+    /// see: https://docs.oracle.com/javase/tutorial/java/package/namingpkgs.html
     /// </summary>
-    public override string ModId { get; set; } = "editdatabase.6870c13c805959c35694f8b9";
+    public override string ModId { get; set; } = "com.sp-tarkov.examples.editdatabase";
     public override string Name { get; set; } = "EditDatabaseExample";
     public override string Author { get; set; } = "SPTarkov";
     public override List<string>? Contributors { get; set; }

--- a/3EditSptConfig/EditConfigs.cs
+++ b/3EditSptConfig/EditConfigs.cs
@@ -18,7 +18,7 @@ namespace _3EditSptConfig;
 /// </summary>
 public record ModMetadata : AbstractModMetadata
 {
-    public override string ModId { get; set; } = "editsptconfig.6870c382923546b18273fe95";
+    public override string ModId { get; set; } = "com.sp-tarkov.examples.editsptconfig";
     public override string Name { get; set; } = "EditConfigsExample";
     public override string Author { get; set; } = "SPTarkov";
     public override List<string>? Contributors { get; set; }

--- a/4ReadCustomJson5Config/ReadJson5Config.cs
+++ b/4ReadCustomJson5Config/ReadJson5Config.cs
@@ -18,7 +18,7 @@ namespace _4ReadCustomJson5Config;
 /// </summary>
 public record ModMetadata : AbstractModMetadata
 {
-    public override string ModId { get; set; } = "readjson5config.6870c3e3aad58f19c67b14e1";
+    public override string ModId { get; set; } = "com.sp-tarkov.examples.readjson5config";
     public override string Name { get; set; } = "ReadJson5ConfigExample";
     public override string Author { get; set; } = "SPTarkov";
     public override List<string>? Contributors { get; set; }

--- a/5ReadCustomJsonConfig/ReadJsonConfig.cs
+++ b/5ReadCustomJsonConfig/ReadJsonConfig.cs
@@ -17,7 +17,7 @@ namespace _5ReadCustomJsonConfig;
 /// </summary>
 public record ModMetadata : AbstractModMetadata
 {
-    public override string ModId { get; set; } = "readjsonconfig.6870c431fadd199de004a919";
+    public override string ModId { get; set; } = "com.sp-tarkov.examples.readjsonconfig";
     public override string Name { get; set; } = "ReadJsonConfigExample";
     public override string Author { get; set; } = "SPTarkov";
     public override List<string>? Contributors { get; set; }

--- a/6.1OverrideMethodHarmony/OverrideMethodHarmony.cs
+++ b/6.1OverrideMethodHarmony/OverrideMethodHarmony.cs
@@ -18,7 +18,7 @@ namespace _6._1OverrideMethodHarmony;
 /// </summary>
 public record ModMetadata : AbstractModMetadata
 {
-    public override string ModId { get; set; } = "overridemethodharmony.6870c447103ad3daed8a9baf";
+    public override string ModId { get; set; } = "com.sp-tarkov.examples.overridemethodharmony";
     public override string Name { get; set; } = "OverrideMethodHarmonyExample";
     public override string Author { get; set; } = "SPTarkov";
     public override List<string>? Contributors { get; set; }

--- a/6OverrideMethod/OverrideMethod.cs
+++ b/6OverrideMethod/OverrideMethod.cs
@@ -18,7 +18,7 @@ namespace _6OverrideMethod;
 /// </summary>
 public record ModMetadata : AbstractModMetadata
 {
-    public override string ModId { get; set; } = "overridemethod.6870c483bad1c6d60765702b";
+    public override string ModId { get; set; } = "com.sp-tarkov.examples.overridemethod";
     public override string Name { get; set; } = "OverrideMethodExample";
     public override string Author { get; set; } = "SPTarkov";
     public override List<string>? Contributors { get; set; }

--- a/7UseMultipleClasses/UseMultipleClasses.cs
+++ b/7UseMultipleClasses/UseMultipleClasses.cs
@@ -7,7 +7,7 @@ namespace _7UseMultipleClasses;
 
 public record ModMetadata : AbstractModMetadata
 {
-    public override string ModId { get; set; } = "multipleclasses.6870c4a9c0d7e7b76f5aeeeb";
+    public override string ModId { get; set; } = "com.sp-tarkov.examples.multipleclasses";
     public override string Name { get; set; } = "UseMultipleClassesExample";
     public override string Author { get; set; } = "SPTarkov";
     public override List<string>? Contributors { get; set; }

--- a/8OnLoad/OnLoadExample.cs
+++ b/8OnLoad/OnLoadExample.cs
@@ -15,7 +15,7 @@ namespace _8OnLoad;
 /// </summary>
 public record ModMetadata : AbstractModMetadata
 {
-    public override string ModId { get; set; } = "onload.6870c52076c4e995517ece1c";
+    public override string ModId { get; set; } = "com.sp-tarkov.examples.onload";
     public override string Name { get; set; } = "OnLoadExampleExample";
     public override string Author { get; set; } = "SPTarkov";
     public override List<string>? Contributors { get; set; }

--- a/9OnUpdate/OnUpdateExample.cs
+++ b/9OnUpdate/OnUpdateExample.cs
@@ -15,7 +15,7 @@ namespace _9OnUpdate;
 /// </summary>
 public record ModMetadata : AbstractModMetadata
 {
-    public override string ModId { get; set; } = "onupdate.6870ced702620776e95828b2";
+    public override string ModId { get; set; } = "com.sp-tarkov.examples.onupdate";
     public override string Name { get; set; } = "OnUpdateExample";
     public override string Author { get; set; } = "SPTarkov";
     public override List<string>? Contributors { get; set; }


### PR DESCRIPTION
As we will want client and server mods to have the same ModId/Plugin GUID when a mod contains both sides, we should push users to use a format similar to the BepInEx recommendation in their mods.

I've updated the mod examples to use the reverse-domain notation, and updated the two comments to note that this is the recommended approach. This follows BepInEx's documentation here: https://docs.bepinex.dev/articles/dev_guide/plugin_tutorial/2_plugin_start.html#basic-information-about-the-plugin