### PR TITLE
Remove the version number from the output folder for mod examples

### DIFF
--- a/10CustomRoute/10CustomRoute.csproj
+++ b/10CustomRoute/10CustomRoute.csproj
@@ -8,7 +8,7 @@
     <OutputType>Library</OutputType>
     <Version>0.0.1</Version>
     <!-- The two lines below will set the output path for the binaries -->
-    <OutputPath>bin\$(Configuration)\$(ProjectName)\$(AssemblyName)-$(Version)\</OutputPath>
+    <OutputPath>bin\$(Configuration)\$(ProjectName)\$(AssemblyName)\</OutputPath>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
   </PropertyGroup>
   <ItemGroup>

--- a/11RegisterClassesInDI/11RegisterClassesInDI.csproj
+++ b/11RegisterClassesInDI/11RegisterClassesInDI.csproj
@@ -8,7 +8,7 @@
     <OutputType>Library</OutputType>
     <Version>0.0.1</Version>
     <!-- The two lines below will set the output path for the binaries -->
-    <OutputPath>bin\$(Configuration)\$(ProjectName)\$(AssemblyName)-$(Version)\</OutputPath>
+    <OutputPath>bin\$(Configuration)\$(ProjectName)\$(AssemblyName)\</OutputPath>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
   </PropertyGroup>
   <ItemGroup>

--- a/12Bundle/12Bundle.csproj
+++ b/12Bundle/12Bundle.csproj
@@ -8,7 +8,7 @@
     <OutputType>Library</OutputType>
     <Version>0.0.1</Version>
     <!-- The two lines below will set the output path for the binaries -->
-    <OutputPath>bin\$(Configuration)\$(ProjectName)\$(AssemblyName)-$(Version)\</OutputPath>
+    <OutputPath>bin\$(Configuration)\$(ProjectName)\$(AssemblyName)\</OutputPath>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
   </PropertyGroup>
   <ItemGroup>

--- a/13.1AddTraderWithDynamicAssorts/13.1AddTraderWithDynamicAssorts.csproj
+++ b/13.1AddTraderWithDynamicAssorts/13.1AddTraderWithDynamicAssorts.csproj
@@ -8,7 +8,7 @@
     <OutputType>Library</OutputType>
     <Version>0.0.1</Version>
     <!-- The two lines below will set the output path for the binaries -->
-    <OutputPath>bin\$(Configuration)\$(ProjectName)\$(AssemblyName)-$(Version)\</OutputPath>
+    <OutputPath>bin\$(Configuration)\$(ProjectName)\$(AssemblyName)\</OutputPath>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
   </PropertyGroup>
   <ItemGroup>

--- a/13AddTraderWithAssortJson/13AddTraderWithAssortJson.csproj
+++ b/13AddTraderWithAssortJson/13AddTraderWithAssortJson.csproj
@@ -8,7 +8,7 @@
     <OutputType>Library</OutputType>
     <Version>0.0.1</Version>
     <!-- The two lines below will set the output path for the binaries -->
-    <OutputPath>bin\$(Configuration)\$(ProjectName)\$(AssemblyName)-$(Version)\</OutputPath>
+    <OutputPath>bin\$(Configuration)\$(ProjectName)\$(AssemblyName)\</OutputPath>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
   </PropertyGroup>
   <ItemGroup>

--- a/14AfterDBLoadHook/14AfterDBLoadHook.csproj
+++ b/14AfterDBLoadHook/14AfterDBLoadHook.csproj
@@ -8,7 +8,7 @@
     <OutputType>Library</OutputType>
     <Version>0.0.1</Version>
     <!-- The two lines below will set the output path for the binaries -->
-    <OutputPath>bin\$(Configuration)\$(ProjectName)\$(AssemblyName)-$(Version)\</OutputPath>
+    <OutputPath>bin\$(Configuration)\$(ProjectName)\$(AssemblyName)\</OutputPath>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
   </PropertyGroup>
   <ItemGroup>

--- a/15HttpListenerExample/15HttpListenerExample.csproj
+++ b/15HttpListenerExample/15HttpListenerExample.csproj
@@ -8,7 +8,7 @@
     <OutputType>Library</OutputType>
     <Version>0.0.1</Version>
     <!-- The two lines below will set the output path for the binaries -->
-    <OutputPath>bin\$(Configuration)\$(ProjectName)\$(AssemblyName)-$(Version)\</OutputPath>
+    <OutputPath>bin\$(Configuration)\$(ProjectName)\$(AssemblyName)\</OutputPath>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
   </PropertyGroup>
 

--- a/18.1CustomItemServiceLootBox/18.1CustomItemServiceLootBox.csproj
+++ b/18.1CustomItemServiceLootBox/18.1CustomItemServiceLootBox.csproj
@@ -8,7 +8,7 @@
     <OutputType>Library</OutputType>
     <Version>0.0.1</Version>
     <!-- The two lines below will set the output path for the binaries -->
-    <OutputPath>bin\$(Configuration)\$(ProjectName)\$(AssemblyName)-$(Version)\</OutputPath>
+    <OutputPath>bin\$(Configuration)\$(ProjectName)\$(AssemblyName)\</OutputPath>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
   </PropertyGroup>
   <ItemGroup>

--- a/18CustomItemService/18CustomItemService.csproj
+++ b/18CustomItemService/18CustomItemService.csproj
@@ -8,7 +8,7 @@
     <OutputType>Library</OutputType>
     <Version>0.0.1</Version>
     <!-- The two lines below will set the output path for the binaries -->
-    <OutputPath>bin\$(Configuration)\$(ProjectName)\$(AssemblyName)-$(Version)\</OutputPath>
+    <OutputPath>bin\$(Configuration)\$(ProjectName)\$(AssemblyName)\</OutputPath>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
   </PropertyGroup>
 

--- a/1Logging/01Logging.csproj
+++ b/1Logging/01Logging.csproj
@@ -8,7 +8,7 @@
     <OutputType>Library</OutputType>
     <Version>0.0.1</Version>
     <!-- The two lines below will set the output path for the binaries -->
-    <OutputPath>bin\$(Configuration)\$(ProjectName)\$(AssemblyName)-$(Version)\</OutputPath>
+    <OutputPath>bin\$(Configuration)\$(ProjectName)\$(AssemblyName)\</OutputPath>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
   </PropertyGroup>
 

--- a/20CustomChatBot/20CustomChatBot.csproj
+++ b/20CustomChatBot/20CustomChatBot.csproj
@@ -8,7 +8,7 @@
     <OutputType>Library</OutputType>
     <Version>0.0.1</Version>
     <!-- The two lines below will set the output path for the binaries -->
-    <OutputPath>bin\$(Configuration)\$(ProjectName)\$(AssemblyName)-$(Version)\</OutputPath>
+    <OutputPath>bin\$(Configuration)\$(ProjectName)\$(AssemblyName)\</OutputPath>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
   </PropertyGroup>
 

--- a/21CustomCommandoCommand/21CustomCommandoCommand.csproj
+++ b/21CustomCommandoCommand/21CustomCommandoCommand.csproj
@@ -8,7 +8,7 @@
     <OutputType>Library</OutputType>
     <Version>0.0.1</Version>
     <!-- The two lines below will set the output path for the binaries -->
-    <OutputPath>bin\$(Configuration)\$(ProjectName)\$(AssemblyName)-$(Version)\</OutputPath>
+    <OutputPath>bin\$(Configuration)\$(ProjectName)\$(AssemblyName)\</OutputPath>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
   </PropertyGroup>
 

--- a/22CustomSptCommand/22CustomSptCommand.csproj
+++ b/22CustomSptCommand/22CustomSptCommand.csproj
@@ -8,7 +8,7 @@
     <OutputType>Library</OutputType>
     <Version>0.0.1</Version>
     <!-- The two lines below will set the output path for the binaries -->
-    <OutputPath>bin\$(Configuration)\$(ProjectName)\$(AssemblyName)-$(Version)\</OutputPath>
+    <OutputPath>bin\$(Configuration)\$(ProjectName)\$(AssemblyName)\</OutputPath>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
   </PropertyGroup>
 

--- a/23CustomAbstractChatBot/23CustomAbstractChatBot.csproj
+++ b/23CustomAbstractChatBot/23CustomAbstractChatBot.csproj
@@ -8,7 +8,7 @@
     <OutputType>Library</OutputType>
     <Version>0.0.1</Version>
     <!-- The two lines below will set the output path for the binaries -->
-    <OutputPath>bin\$(Configuration)\$(ProjectName)\$(AssemblyName)-$(Version)\</OutputPath>
+    <OutputPath>bin\$(Configuration)\$(ProjectName)\$(AssemblyName)\</OutputPath>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
   </PropertyGroup>
   <ItemGroup>

--- a/24Websocket/24Websocket.csproj
+++ b/24Websocket/24Websocket.csproj
@@ -8,7 +8,7 @@
     <OutputType>Library</OutputType>
     <Version>0.0.1</Version>
     <!-- The two lines below will set the output path for the binaries -->
-    <OutputPath>bin\$(Configuration)\$(ProjectName)\$(AssemblyName)-$(Version)\</OutputPath>
+    <OutputPath>bin\$(Configuration)\$(ProjectName)\$(AssemblyName)\</OutputPath>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
   </PropertyGroup>
   <ItemGroup>

--- a/25AddCustomLocales/25AddCustomLocales.csproj
+++ b/25AddCustomLocales/25AddCustomLocales.csproj
@@ -8,7 +8,7 @@
         <OutputType>Library</OutputType>
         <Version>0.0.1</Version>
         <!-- The two lines below will set the output path for the binaries -->
-        <OutputPath>bin\$(Configuration)\$(ProjectName)\$(AssemblyName)-$(Version)\</OutputPath>
+        <OutputPath>bin\$(Configuration)\$(ProjectName)\$(AssemblyName)\</OutputPath>
         <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
     </PropertyGroup>
 

--- a/2EditDatabase/02EditDatabase.csproj
+++ b/2EditDatabase/02EditDatabase.csproj
@@ -8,7 +8,7 @@
     <OutputType>Library</OutputType>
     <Version>0.0.1</Version>
     <!-- The two lines below will set the output path for the binaries -->
-    <OutputPath>bin\$(Configuration)\$(ProjectName)\$(AssemblyName)-$(Version)\</OutputPath>
+    <OutputPath>bin\$(Configuration)\$(ProjectName)\$(AssemblyName)\</OutputPath>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
   </PropertyGroup>
 

--- a/3EditSptConfig/03EditSptConfig.csproj
+++ b/3EditSptConfig/03EditSptConfig.csproj
@@ -8,7 +8,7 @@
     <OutputType>Library</OutputType>
     <Version>0.0.1</Version>
     <!-- The two lines below will set the output path for the binaries -->
-    <OutputPath>bin\$(Configuration)\$(ProjectName)\$(AssemblyName)-$(Version)\</OutputPath>
+    <OutputPath>bin\$(Configuration)\$(ProjectName)\$(AssemblyName)\</OutputPath>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
   </PropertyGroup>
 

--- a/4ReadCustomJson5Config/04ReadCustomJson5Config.csproj
+++ b/4ReadCustomJson5Config/04ReadCustomJson5Config.csproj
@@ -8,7 +8,7 @@
     <OutputType>Library</OutputType>
     <Version>0.0.1</Version>
     <!-- The two lines below will set the output path for the binaries -->
-    <OutputPath>bin\$(Configuration)\$(ProjectName)\$(AssemblyName)-$(Version)\</OutputPath>
+    <OutputPath>bin\$(Configuration)\$(ProjectName)\$(AssemblyName)\</OutputPath>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>

--- a/5ReadCustomJsonConfig/05ReadCustomJsonConfig.csproj
+++ b/5ReadCustomJsonConfig/05ReadCustomJsonConfig.csproj
@@ -8,7 +8,7 @@
     <OutputType>Library</OutputType>
     <Version>0.0.1</Version>
     <!-- The two lines below will set the output path for the binaries -->
-    <OutputPath>bin\$(Configuration)\$(ProjectName)\$(AssemblyName)-$(Version)\</OutputPath>
+    <OutputPath>bin\$(Configuration)\$(ProjectName)\$(AssemblyName)\</OutputPath>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
   </PropertyGroup>
 

--- a/6.1OverrideMethodHarmony/06.1OverrideMethodHarmony.csproj
+++ b/6.1OverrideMethodHarmony/06.1OverrideMethodHarmony.csproj
@@ -8,7 +8,7 @@
 		<OutputType>Library</OutputType>
 		<Version>0.0.1</Version>
 		<!-- The two lines below will set the output path for the binaries -->
-		<OutputPath>bin\$(Configuration)\$(ProjectName)\$(AssemblyName)-$(Version)\</OutputPath>
+		<OutputPath>bin\$(Configuration)\$(ProjectName)\$(AssemblyName)\</OutputPath>
 		<AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
 	</PropertyGroup>
 

--- a/6OverrideMethod/06OverrideMethod.csproj
+++ b/6OverrideMethod/06OverrideMethod.csproj
@@ -8,7 +8,7 @@
     <OutputType>Library</OutputType>
     <Version>0.0.1</Version>
     <!-- The two lines below will set the output path for the binaries -->
-    <OutputPath>bin\$(Configuration)\$(ProjectName)\$(AssemblyName)-$(Version)\</OutputPath>
+    <OutputPath>bin\$(Configuration)\$(ProjectName)\$(AssemblyName)\</OutputPath>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
   </PropertyGroup>
 

--- a/7UseMultipleClasses/07UseMultipleClasses.csproj
+++ b/7UseMultipleClasses/07UseMultipleClasses.csproj
@@ -8,7 +8,7 @@
     <OutputType>Library</OutputType>
     <Version>0.0.1</Version>
     <!-- The two lines below will set the output path for the binaries -->
-    <OutputPath>bin\$(Configuration)\$(ProjectName)\$(AssemblyName)-$(Version)\</OutputPath>
+    <OutputPath>bin\$(Configuration)\$(ProjectName)\$(AssemblyName)\</OutputPath>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
   </PropertyGroup>
 

--- a/8OnLoad/08OnLoad.csproj
+++ b/8OnLoad/08OnLoad.csproj
@@ -8,7 +8,7 @@
     <OutputType>Library</OutputType>
     <Version>0.0.1</Version>
     <!-- The two lines below will set the output path for the binaries -->
-    <OutputPath>bin\$(Configuration)\$(ProjectName)\$(AssemblyName)-$(Version)\</OutputPath>
+    <OutputPath>bin\$(Configuration)\$(ProjectName)\$(AssemblyName)\</OutputPath>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
   </PropertyGroup>
 

--- a/9OnUpdate/09OnUpdate.csproj
+++ b/9OnUpdate/09OnUpdate.csproj
@@ -8,7 +8,7 @@
     <OutputType>Library</OutputType>
     <Version>0.0.1</Version>
     <!-- The two lines below will set the output path for the binaries -->
-    <OutputPath>bin\$(Configuration)\$(ProjectName)\$(AssemblyName)-$(Version)\</OutputPath>
+    <OutputPath>bin\$(Configuration)\$(ProjectName)\$(AssemblyName)\</OutputPath>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
   </PropertyGroup>
 


### PR DESCRIPTION
It's bad practice to include the version number in the mod folder name, and having it output that format by default will lead to mod developers adopting that practice