### PR TITLE
Add Router Hook example

### DIFF
--- a/26RouterHook/26RouterHook.csproj
+++ b/26RouterHook/26RouterHook.csproj
@@ -1,0 +1,39 @@
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
+
+    <PropertyGroup>
+        <TargetFramework>net9.0</TargetFramework>
+        <RootNamespace>_26RouterHook</RootNamespace>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+        <OutputType>Library</OutputType>
+        <Version>0.0.1</Version>
+        <!-- The two lines below will set the output path for the binaries -->
+        <OutputPath>bin\$(Configuration)\$(ProjectName)\$(AssemblyName)\</OutputPath>
+        <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="SPTarkov.Common" Version="4.0.1" />
+        <PackageReference Include="SPTarkov.DI" Version="4.0.1" />
+        <PackageReference Include="SPTarkov.Server.Core" Version="4.0.1" />
+    </ItemGroup>
+
+    <ItemGroup>
+        <None Include="$(MSBuildProjectFullPath).user" Condition="Exists('$(MSBuildProjectFullPath).user')" />
+    </ItemGroup>
+
+    <PropertyGroup>
+        <ModsDirectoryPath>C:\Users\Rob\Documents\Applications\SPTarkov\Dev\SPT-4\SPT\user\mods\$(MSBuildProjectName)</ModsDirectoryPath>
+    </PropertyGroup>
+
+    <Target Name="CopyToSPT" AfterTargets="AfterBuild" Condition="'$(SPTPath)' != ''">
+        <Message Importance="high" Text="Copying mods to $(ModsDirectoryPath)" />
+        <ItemGroup>
+            <FilesToCopy Include="$(OutputPath)$(TargetName)$(TargetExt)" />
+            <FilesToCopy Include="$(OutputPath)$(TargetName).pdb" />
+        </ItemGroup>
+        <Copy SourceFiles="@(FilesToCopy)" DestinationFolder="$(ModsDirectoryPath)" ContinueOnError="false" />
+        <Message Text="Files copied" />
+    </Target>
+
+</Project>

--- a/26RouterHook/26RouterHook.csproj
+++ b/26RouterHook/26RouterHook.csproj
@@ -18,22 +18,4 @@
         <PackageReference Include="SPTarkov.Server.Core" Version="4.0.1" />
     </ItemGroup>
 
-    <ItemGroup>
-        <None Include="$(MSBuildProjectFullPath).user" Condition="Exists('$(MSBuildProjectFullPath).user')" />
-    </ItemGroup>
-
-    <PropertyGroup>
-        <ModsDirectoryPath>C:\Users\Rob\Documents\Applications\SPTarkov\Dev\SPT-4\SPT\user\mods\$(MSBuildProjectName)</ModsDirectoryPath>
-    </PropertyGroup>
-
-    <Target Name="CopyToSPT" AfterTargets="AfterBuild" Condition="'$(SPTPath)' != ''">
-        <Message Importance="high" Text="Copying mods to $(ModsDirectoryPath)" />
-        <ItemGroup>
-            <FilesToCopy Include="$(OutputPath)$(TargetName)$(TargetExt)" />
-            <FilesToCopy Include="$(OutputPath)$(TargetName).pdb" />
-        </ItemGroup>
-        <Copy SourceFiles="@(FilesToCopy)" DestinationFolder="$(ModsDirectoryPath)" ContinueOnError="false" />
-        <Message Text="Files copied" />
-    </Target>
-
 </Project>

--- a/26RouterHook/26RouterHook.csproj
+++ b/26RouterHook/26RouterHook.csproj
@@ -1,21 +1,21 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
-    <PropertyGroup>
-        <TargetFramework>net9.0</TargetFramework>
-        <RootNamespace>_26RouterHook</RootNamespace>
-        <ImplicitUsings>enable</ImplicitUsings>
-        <Nullable>enable</Nullable>
-        <OutputType>Library</OutputType>
-        <Version>0.0.1</Version>
-        <!-- The two lines below will set the output path for the binaries -->
-        <OutputPath>bin\$(Configuration)\$(ProjectName)\$(AssemblyName)\</OutputPath>
-        <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
-    </PropertyGroup>
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <RootNamespace>_26RouterHook</RootNamespace>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <OutputType>Library</OutputType>
+    <Version>0.0.1</Version>
+    <!-- The two lines below will set the output path for the binaries -->
+    <OutputPath>bin\$(Configuration)\$(ProjectName)\$(AssemblyName)\</OutputPath>
+    <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
+  </PropertyGroup>
 
-    <ItemGroup>
-        <PackageReference Include="SPTarkov.Common" Version="4.0.1" />
-        <PackageReference Include="SPTarkov.DI" Version="4.0.1" />
-        <PackageReference Include="SPTarkov.Server.Core" Version="4.0.1" />
-    </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="SPTarkov.Common" Version="4.0.3" />
+    <PackageReference Include="SPTarkov.DI" Version="4.0.3" />
+    <PackageReference Include="SPTarkov.Server.Core" Version="4.0.3" />
+  </ItemGroup>
 
 </Project>

--- a/26RouterHook/RouterHook.cs
+++ b/26RouterHook/RouterHook.cs
@@ -1,0 +1,115 @@
+﻿using SPTarkov.DI.Annotations;
+using SPTarkov.Server.Core.DI;
+using SPTarkov.Server.Core.Models.Common;
+using SPTarkov.Server.Core.Models.Spt.Mod;
+using SPTarkov.Server.Core.Models.Utils;
+using SPTarkov.Server.Core.Utils;
+
+namespace _26RouterHook;
+
+/// <summary>
+/// This is the replacement for the former package.json data. This is required for all mods.
+///
+/// This is where we define all the metadata associated with this mod.
+/// You don't have to do anything with it, other than fill it out.
+/// All properties must be overriden, properties you don't use may be left null.
+/// It is read by the mod loader when this mod is loaded.
+/// </summary>
+public record ModMetadata : AbstractModMetadata
+{
+    public override string ModGuid { get; init; } = "com.sp-tarkov.examples.routerhook";
+    public override string Name { get; init; } = "RouterHookExample";
+    public override string Author { get; init; } = "SPTarkov";
+    public override List<string>? Contributors { get; init; }
+    public override SemanticVersioning.Version Version { get; init; } = new("1.0.0");
+    public override SemanticVersioning.Range SptVersion { get; init; } = new("~4.0.0");
+    
+    
+    public override List<string>? Incompatibilities { get; init; }
+    public override Dictionary<string, SemanticVersioning.Range>? ModDependencies { get; init; }
+    public override string? Url { get; init; }
+    public override bool? IsBundleMod { get; init; }
+    public override string? License { get; init; } = "MIT";
+}
+
+[Injectable]
+public class RouterHook : StaticRouter
+{
+    private static ISptLogger<RouterHook> _logger;
+
+    public RouterHook(
+        JsonUtil jsonUtil,
+        ISptLogger<RouterHook> logger) : base(
+        jsonUtil,
+        // Add an array of routes to which we want to listen
+        GetRouteListeners()
+    )
+    {
+        _logger = logger;
+    }
+
+    private static List<RouteAction> GetRouteListeners()
+    {
+        return
+        [
+            new RouteAction(
+                "/client/game/start",
+                async (
+                    url,
+                    info,
+                    sessionId,
+                    output
+                ) => await HandleRouteSync(url, sessionId, output)
+            ),
+            new RouteAction(
+                "/client/game/logout",
+                async (
+                    url,
+                    info,
+                    sessionId,
+                    output
+                ) => await HandleRouteAsync(url, sessionId, output)
+            )
+        ];
+    }
+
+    /**
+     * Example of an asynchronous route listener
+     * This WILL NOT block the original route action while executing
+     */
+    private static ValueTask<string> HandleRouteAsync(string url, MongoId sessionId, String? output)
+    {
+        // Spin off a new task to run asynchronously
+        _ = Task.Run(async () => 
+        {
+            // Your mod's asynchronous code goes here
+            
+            // Simulates some asynchronous work (DELETE THIS IN PRODUCTION MODS)
+            _logger.Info($"Async work started from route {url} for session {sessionId}");
+            // await Task.Delay(10000);
+            Thread.Sleep(10000);
+            _logger.Info($"Async work completed from route {url} for session {sessionId}");
+        });
+
+        // Unless you want to modify what the route returned, return the output unmodified.
+        return new ValueTask<string>(output);
+    }
+
+    /**
+     * Example of a synchronous route listener
+     * This WILL block the original route action while executing
+     */
+    private static ValueTask<string> HandleRouteSync(string url, MongoId sessionId, String? output)
+    {
+        // Your mod's synchronous code goes here
+        
+        // Simulates some synchronous work (DELETE THIS IN PRODUCTION MODS)
+        _logger.Info($"Synchronous work started from route {url} for session {sessionId}");
+        Thread.Sleep(10000);
+        _logger.Info($"Synchronous work completed from route {url} for session {sessionId}");
+
+        // Unless you want to modify what the route returned, return the output unmodified.
+        return new ValueTask<string>(output);
+    }
+    
+}

--- a/26RouterHook/RouterHook.cs
+++ b/26RouterHook/RouterHook.cs
@@ -59,7 +59,7 @@ public class RouterHook : StaticRouter
                     info,
                     sessionId,
                     output
-                ) => await HandleRouteSync(url, sessionId, output)
+                ) => await HandleRoute(url, sessionId, output)
             ),
             new RouteAction(
                 "/client/game/logout",
@@ -68,45 +68,19 @@ public class RouterHook : StaticRouter
                     info,
                     sessionId,
                     output
-                ) => await HandleRouteAsync(url, sessionId, output)
+                ) => await HandleRoute(url, sessionId, output)
             )
         ];
     }
 
     /**
-     * Example of an asynchronous route listener
-     * This WILL NOT block the original route action while executing
+     * Example of a route listener
      */
-    private static ValueTask<string> HandleRouteAsync(string url, MongoId sessionId, String? output)
+    private static ValueTask<string> HandleRoute(string url, MongoId sessionId, String? output)
     {
-        // Spin off a new task to run asynchronously
-        _ = Task.Run(async () => 
-        {
-            // Your mod's asynchronous code goes here
-            
-            // Simulates some asynchronous work (DELETE THIS IN PRODUCTION MODS)
-            _logger.Info($"Async work started from route {url} for session {sessionId}");
-            // await Task.Delay(10000);
-            Thread.Sleep(10000);
-            _logger.Info($"Async work completed from route {url} for session {sessionId}");
-        });
-
-        // Unless you want to modify what the route returned, return the output unmodified.
-        return new ValueTask<string>(output);
-    }
-
-    /**
-     * Example of a synchronous route listener
-     * This WILL block the original route action while executing
-     */
-    private static ValueTask<string> HandleRouteSync(string url, MongoId sessionId, String? output)
-    {
-        // Your mod's synchronous code goes here
-        
-        // Simulates some synchronous work (DELETE THIS IN PRODUCTION MODS)
-        _logger.Info($"Synchronous work started from route {url} for session {sessionId}");
-        Thread.Sleep(10000);
-        _logger.Info($"Synchronous work completed from route {url} for session {sessionId}");
+        // Your mod's code goes here
+        _logger.Info($"Hooked route {url} for session {sessionId}");
+        Thread.Sleep(5000); // Simulates the mod doing some work (DELETE THIS IN PRODUCTION MODS)
 
         // Unless you want to modify what the route returned, return the output unmodified.
         return new ValueTask<string>(output);

--- a/ModExamples.sln
+++ b/ModExamples.sln
@@ -53,6 +53,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "25AddCustomLocales", "25Add
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "06.1OverrideMethodHarmony", "6.1OverrideMethodHarmony\06.1OverrideMethodHarmony.csproj", "{04865471-AB89-4D98-AAD6-283F099148C7}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "26RouterHook", "26RouterHook\26RouterHook.csproj", "{36CB118F-2114-4CED-A7EA-573E11AB96DC}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -159,6 +161,10 @@ Global
 		{04865471-AB89-4D98-AAD6-283F099148C7}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{04865471-AB89-4D98-AAD6-283F099148C7}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{04865471-AB89-4D98-AAD6-283F099148C7}.Release|Any CPU.Build.0 = Release|Any CPU
+		{36CB118F-2114-4CED-A7EA-573E11AB96DC}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{36CB118F-2114-4CED-A7EA-573E11AB96DC}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{36CB118F-2114-4CED-A7EA-573E11AB96DC}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{36CB118F-2114-4CED-A7EA-573E11AB96DC}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
I noticed there was no equivalent to the old Router Hooks example, https://github.com/sp-tarkov/mod-examples/blob/master/TypeScript/9RouterHooks/src/mod.ts, so this is my attempt at creating one. I expect this will start/continue a conversation from a few days ago in the mods-development channel about the best way to implement router hooks (I am FriedEngineer in discord).

First off, I've written very little C# so I am likely just missing some basic/background knowledge here. Second, this code is minimally functional however a few things feel...weird to me, but I didn't see another way to handle them.
- returning `new ValueTask<string>(output)` with the output that the hooked route was sending
  - In my head a hook should only be able to hook onto a route non-invasively  (ie not be able to change the output)
- By "default" the additional `RouteAction` seems to be blocking the "original" RouteAction
  - I added the `HandleRouteAsync` example to showcase non-blocking mod code. We could remove the `HandleRouteSync` method entirely and just trust that people will generally use it, so that the hooked route is not blocked, but I could see some use case where blocking would be desired.

Feel free to rip this code to shreds as well, I won't take it personally. If this helps at all to arrive at the point of having a Router Hooks example in this repo, I will be happy.